### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://deadrobot.visualstudio.com/d2113f27-7c53-414d-92e0-91fa473b00f5/00094eb6-47e2-43d2-be33-1f1430573253/_apis/work/boardbadge/acea58d1-572c-40eb-8c84-e8fc1ff2ed3b)](https://deadrobot.visualstudio.com/d2113f27-7c53-414d-92e0-91fa473b00f5/_boards/board/t/00094eb6-47e2-43d2-be33-1f1430573253/Microsoft.RequirementCategory)
 # PSSAToJunit: A module to convert PSScriptAnalyzer reports to jUnit
 
 [![Mega-Linter](https://github.com/tonylea/PSSAToJunit/workflows/Mega-Linter/badge.svg?branch=main)](https://github.com/tonylea/PSSAToJunit/actions?query=workflow%3AMega-Linter+branch%3Amain)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://deadrobot.visualstudio.com/d2113f27-7c53-414d-92e0-91fa473b00f5/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.