### PR TITLE
fix: add proga to cspell words list to fix release pipeline

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -63,6 +63,7 @@
         "markdownlint",
         "nuspec",
         "platy",
+        "proga",
         "platyps",
         "privatefunc",
         "pssa",


### PR DESCRIPTION
PlatyPS generates 'proga' (the alias for -ProgressAction added in PowerShell 7.4) in regenerated docs, causing the pre-commit cspell check to fail when the release pipeline amends the release commit.

Closes #21