### PR TITLE
fix: push HEAD to main ref to fix detached HEAD push failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Push commit and tag
         if: steps.check.outputs.should_release == 'true'
-        run: git push --follow-tags origin main
+        run: git push --follow-tags origin HEAD:main
 
       - name: Create staging folder
         if: steps.check.outputs.should_release == 'true'


### PR DESCRIPTION
Checkout via head_sha puts git in detached HEAD state so there is no local main branch. Pushing HEAD:main explicitly targets the remote ref.

Closes #23